### PR TITLE
Fixed empty line after formating repeated

### DIFF
--- a/src/protobuf.Text/TextFormatter.cs
+++ b/src/protobuf.Text/TextFormatter.cs
@@ -240,6 +240,7 @@ namespace Protobuf.Text
                 {
                     writer.Write(PropertySeparator);
                 }
+                first = false;
 
                 if (field.IsRepeated && !field.IsMap)
                 {
@@ -249,7 +250,6 @@ namespace Protobuf.Text
 
                 WriteSingleField(writer, field, value);
 
-                first = false;
             }
             return !first;
         }
@@ -295,15 +295,19 @@ namespace Protobuf.Text
                     first = false;
                 }                
                 writer.Write(" ]");
-                writer.Write(PropertySeparator);
             }
             else
             {
+                int numberOfElements = (value as IList).Count;
                 // Repeated field.  Print each element.
                 foreach (object element in (IEnumerable) value)
                 {
                     WriteSingleField(writer, field, element);
-                    writer.Write(PropertySeparator);
+                    numberOfElements--;
+                    if(numberOfElements > 0)
+                    {
+                        writer.Write(PropertySeparator);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes a "cosmetic bug" that formatting of repeated generates a extra empty line after it is done

afik. the source of the problem is that first is not set when printing repeated as the loop ends with continue.
https://github.com/SciSharp/protobuf.Text/blob/5cf2c4661d43aba466a6fa4c830c7857a5e5dee9/src/protobuf.Text/TextFormatter.cs#L244-L252

After this is fixed there is a line generated before new fields is formatted, but the repeated formatting is already compensating for the missing separator so it needs to be fixed to and that is the changes from line 290+