### PR TITLE
FormatRepeatedValueOnSingleLine bug: Checking that size is more than 0 before access

### DIFF
--- a/src/protobuf.Text/TextFormatter.cs
+++ b/src/protobuf.Text/TextFormatter.cs
@@ -278,7 +278,7 @@ namespace Protobuf.Text
 
         private void WriteRepeatedField(TextWriter writer, FieldDescriptor field, object value)
         {
-            if(settings.FormatRepeatedValueOnSingleLine && (value as IList)[0].GetType().IsValueType)
+            if(settings.FormatRepeatedValueOnSingleLine && (value as IList).Count > 0 && (value as IList)[0].GetType().IsValueType)
             {
                 writer.Write(field.Name);
                 writer.Write(NameValueSeparator);                


### PR DESCRIPTION
Fixing bug that i made in https://github.com/SciSharp/protobuf.Text/pull/9
It will only happen if FormatRepeatedValueOnSingleLine is true

It checks that the repeated field is non-zero before trying to access it