### PR TITLE
remove quotes around printed enums

### DIFF
--- a/src/protobuf.Text/TextFormatter.cs
+++ b/src/protobuf.Text/TextFormatter.cs
@@ -462,7 +462,7 @@ namespace Protobuf.Text
                     string name = OriginalEnumValueHelper.GetOriginalName(value);
                     if (name != null)
                     {
-                        WriteString(writer, name);
+                        WriteString(writer, name, false);
                     }
                     else
                     {
@@ -753,14 +753,17 @@ namespace Protobuf.Text
         }
 
         /// <summary>
-        /// Writes a string (including leading and trailing double quotes) to a builder, escaping as required.
+        /// Writes a string (including leading and trailing double quotes if addQuotesAroundString is true) to a builder, escaping as required.
         /// </summary>
         /// <remarks>
         /// Other than surrogate pair handling, this code is mostly taken from src/google/protobuf/util/internal/json_escaping.cc.
         /// </remarks>
-        internal static void WriteString(TextWriter writer, string text)
+        internal static void WriteString(TextWriter writer, string text, bool addQuotesAroundString = true)
         {
-            writer.Write('"');
+            if(addQuotesAroundString) {
+                writer.Write('"');
+            }
+
             for (int i = 0; i < text.Length; i++)
             {
                 char c = text[i];
@@ -820,7 +823,9 @@ namespace Protobuf.Text
                         break;
                 }
             }
-            writer.Write('"');
+            if(addQuotesAroundString) {
+                writer.Write('"');
+            }
         }
 
         private const string Hex = "0123456789abcdef";


### PR DESCRIPTION
Having problems reading enums with quotes around them user the official c++ implementation, removing them fixes the problem.

I can make this optional if wanted.

official examples of this can be found here:
https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files
https://protobuf.dev/reference/protobuf/textformat-spec/#example

I have problems finding any prof that this is the case in the c++ code
The best prof i found is to look in the test file below and search for enum
https://github.com/protocolbuffers/protobuf/blob/3667102d91bba05afcb777aa685b1014f521e9bc/src/google/protobuf/text_format_unittest.cc